### PR TITLE
Replace font with montserrat

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { Montserrat } from "next/font/google";
+import "./globals.css";
+
+const montserrat = Montserrat({
+  variable: "--font-montserrat",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Vuk Tacic",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body
+        className={`${montserrat.variable} antialiased bg-zinc-900 text-white min-h-screen font-sans`}
+      >
+        <main className="min-h-screen">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Replace default fonts with Montserrat as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-63468b95-4f0f-48aa-ae4b-bf33e0d9ff0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63468b95-4f0f-48aa-ae4b-bf33e0d9ff0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

